### PR TITLE
Fix/`undefined` href bug

### DIFF
--- a/src/Data/services.data.ts
+++ b/src/Data/services.data.ts
@@ -8,55 +8,55 @@ import X from '@assets/icons/services/x.svg';
 
 export const services_url = (url: string, subject?: string): { [key: string]: string } => {
 	return {
-		email: `mailto:?subject=${subject}&body=${url}`,
-		gmail: `https://mail.google.com/mail/u/0/?ui=2&fs=1&tf=cm&su=${subject}&body=${url}`,
-		telegram: `https://telegram.me/share/url?url=${url}&text=${subject}`,
-		x: `https://x.com/intent/post?url=${url}&text=${subject}`,
-		whatsapp: `https://api.whatsapp.com/send?text=${subject}%20${url}`,
-		'yahoo mail': `http://compose.mail.yahoo.com/?subject=${subject}&body=${url}`,
-		'hacker news': `https://news.ycombinator.com/submitlink?u=${url}&t=${subject}`,
+		Email: `mailto:?subject=${subject}&body=${url}`,
+		Gmail: `https://mail.google.com/mail/u/0/?ui=2&fs=1&tf=cm&su=${subject}&body=${url}`,
+		Telegram: `https://telegram.me/share/url?url=${url}&text=${subject}`,
+		X: `https://x.com/intent/post?url=${url}&text=${subject}`,
+		WhatsApp: `https://api.whatsapp.com/send?text=${subject}%20${url}`,
+		'Yahoo Mail': `http://compose.mail.yahoo.com/?subject=${subject}&body=${url}`,
+		'Hacker News': `https://news.ycombinator.com/submitlink?u=${url}&t=${subject}`,
 	};
 };
 
 export const Services = [
 	{
-		title: 'email',
+		title: 'Email',
 		icon: Email,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/email.svg',
 		bg: '#888990',
 	},
 	{
-		title: 'gmail',
+		title: 'Gmail',
 		icon: Gmail,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/gmail.svg',
 		bg: '#EA4335',
 	},
 	{
-		title: 'telegram',
+		title: 'Telegram',
 		icon: Telegram,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/telegram.svg',
 		bg: '#2CA5E0',
 	},
 	{
-		title: 'x',
+		title: 'X',
 		icon: X,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/x.svg',
 		bg: '#1A1A1A',
 	},
 	{
-		title: 'whatsApp',
+		title: 'WhatsApp',
 		icon: Whatsapp,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/whatsapp.svg',
 		bg: '#12AF0A',
 	},
 	{
-		title: 'yahoo mail',
+		title: 'Yahoo Mail',
 		icon: Yahoo,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/yahoo.svg',
 		bg: '#400090',
 	},
 	{
-		title: 'hacker news',
+		title: 'Hacker News',
 		icon: HackerNews,
 		iconUrl: 'https://github.com/openscilab/mybutton/raw/main/src/Assets/icons/services/hacker-news.svg',
 		bg: '#ff6600',

--- a/src/Views/Pages/GetButton/index.tsx
+++ b/src/Views/Pages/GetButton/index.tsx
@@ -31,7 +31,7 @@ const GetButton = () => {
 		dropdownOpen: false,
 		encodingValue: [],
 	});
-	const [selectedServices, setSelectedServices] = useState<string[]>(['email']);
+	const [selectedServices, setSelectedServices] = useState<string[]>(['Email']);
 
 	// ? -------------------------- Functions ------------------------------
 	const onAddService = (title: string) => {


### PR DESCRIPTION
#### Reference Issues/PRs
#### What does this implement/fix? Explain your changes.
#### Any other comments?
We retrieve the services data from two separate lists in `services.data` file. The `WhatsApp` bug occurred because its title was not identical in `services_url` (which contains template links) and `Services` (which contains base service information). As a result, the `href` link was `undefined` because it referenced a service whose title did not exist in `services_url`.
To prevent similar issues, I updated all service titles in both lists to the names we want to display on our website.