### PR TITLE
Enhancement/custom share

### DIFF
--- a/src/Views/Layout/Navbar/NavBar.tsx
+++ b/src/Views/Layout/Navbar/NavBar.tsx
@@ -9,21 +9,20 @@ import { setOpenShareModal, useLocalCache } from '@src/Tools/Store/slices/LocalC
 const NavBar = () => {
 	const { activePage } = useLocalCache();
 	const { dispatch } = useStore();
-	const setSearchParams = useSearchParams()[1];
+	const [searchParams, setSearchParams] = useSearchParams();
 
 	return (
 		<div className='navbar-layout'>
 			<Navbar className='navbar'>
 				<Navbar.Brand
 					className='nav-brand'
-					onClick={() =>
-						setSearchParams(params => {
-							params.forEach((val, key) => {
-								params.delete(key);
-							});
-							return params;
-						})
-					}>
+					onClick={() => {
+						const newParams = new URLSearchParams(searchParams);
+						searchParams.forEach((_, key) => {
+							newParams.delete(key);
+						});
+						setSearchParams(newParams);
+					}}>
 					<Logo className='logo-text' />
 				</Navbar.Brand>
 

--- a/src/Views/Layout/index.tsx
+++ b/src/Views/Layout/index.tsx
@@ -7,7 +7,7 @@ import PagesRouter from '../Pages/PagesRouter';
 import useStore from '@src/Tools/Store/useStore';
 import { useSearchParams } from 'react-router-dom';
 import { ReactComponent as Bg } from '@assets/Images/bg.svg';
-import { setActivePage } from '@src/Tools/Store/slices/LocalCacheSlice';
+import { setActivePage, setOpenShareModal } from '@src/Tools/Store/slices/LocalCacheSlice';
 import { decode } from '@src/Tools/Utils/URLEncoding';
 
 const Layout = () => {
@@ -18,6 +18,9 @@ const Layout = () => {
 
 	useEffect(() => {
 		dispatch(setActivePage(path));
+		if (path === 'custom_share') {
+			dispatch(setOpenShareModal(true));
+		}
 	}, [path]);
 
 	return (


### PR DESCRIPTION
#### Reference Issues/PRs
#47 
#### What does this implement/fix? Explain your changes.
Custom sharing is supported through the `custom_share` path by opening the `Share` modal and placing the ‍`link` and `subject` parameters of the entered url into the modal's inputs.
Open this link as an example:
https://dev.mybutton.click/?path=custom_share&link=https%3A%2F%2Fwww.test.com&subject=test
#### Any other comments?

