### PR TITLE
Refactor service names

### DIFF
--- a/src/Data/constants.data.ts
+++ b/src/Data/constants.data.ts
@@ -15,6 +15,22 @@ export enum ServiceName {
 	HackerNews = 'Hacker News',
 }
 
+export const standardNaming: { [key: string]: string } = {
+	x: ServiceName.X,
+	email: ServiceName.Email,
+	gmail: ServiceName.Gmail,
+	reddit: ServiceName.Reddit,
+	trello: ServiceName.Trello,
+	blogger: ServiceName.Blogger,
+	yahoo_mail: ServiceName.Yahoo,
+	telegram: ServiceName.Telegram,
+	whatsapp: ServiceName.Whatsapp,
+	facebook: ServiceName.Facebook,
+	linkedin: ServiceName.Linkedin,
+	custom_share: ServiceName.Custom,
+	hacker_news: ServiceName.HackerNews,
+};
+
 export enum SharingMode {
 	Direct = 'direct',
 	Indirect = 'indirect',

--- a/src/Tools/Store/slices/index.ts
+++ b/src/Tools/Store/slices/index.ts
@@ -13,7 +13,7 @@ const reducers = combineReducers({
 			storage,
 			key: 'storage',
 			keyPrefix: `${CONFIG.APP_SHORT_NAME}-`,
-			blacklist: ['openShareModal', 'activePage'],
+			blacklist: ['shareModal', 'activePage'],
 			transforms: [compressor] as any,
 		},
 		LocalCacheReducer.reducer

--- a/src/Tools/Utils/Standardize.ts
+++ b/src/Tools/Utils/Standardize.ts
@@ -1,0 +1,3 @@
+export const toStandardName = (service_name: string) => {
+	return service_name.toLowerCase().replace(' ', '_');
+};

--- a/src/Views/Layout/ShareModal/index.tsx
+++ b/src/Views/Layout/ShareModal/index.tsx
@@ -10,6 +10,7 @@ import { useLocalCache, setShareModal } from '@src/Tools/Store/slices/LocalCache
 import { Checkbox, CheckboxGroup, Col, Modal, Radio, RadioGroup, Row, Tooltip, Whisper } from 'rsuite';
 import { useData } from '@src/Tools/Hooks/useData';
 import { ServiceName } from '@src/Data/constants.data';
+import { toStandardName } from '@src/Tools/Utils/Standardize';
 
 const ShareModal = () => {
 	const { dispatch } = useStore();
@@ -38,7 +39,8 @@ const ShareModal = () => {
 	};
 
 	const getShareLink = (service_title: string, url: string) => {
-		const path = `?path=share&service=${service_title}&subject=${temp.subject}&link=${url}`;
+		const serviceName = toStandardName(service_title);
+		const path = `?path=share&service=${serviceName}&subject=${temp.subject}&link=${url}`;
 		if (temp.encodingValue?.length) {
 			const encoded_path = encode(path);
 			return `${CONFIG.FRONT_DOMAIN}/?encoded=${encoded_path}`;

--- a/src/Views/Pages/GetButton/index.tsx
+++ b/src/Views/Pages/GetButton/index.tsx
@@ -17,6 +17,7 @@ import { setShareModal } from '@src/Tools/Store/slices/LocalCacheSlice';
 import { lightfair } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { ReactComponent as Clone } from '@assets/icons/clone-regular.svg';
 import { Button, Checkbox, CheckboxGroup, Col, Modal, Radio, RadioGroup, Row, Tooltip, Whisper } from 'rsuite';
+import { toStandardName } from '@src/Tools/Utils/Standardize';
 
 const GetButton = () => {
 	const { isMobile } = useWindow();
@@ -49,7 +50,8 @@ const GetButton = () => {
 	};
 
 	const getShareLink = (service_title: string, url: string) => {
-		const path = `?path=share&service=${service_title}&subject=${temp.subject}&link=${url}`;
+		const serviceName = toStandardName(service_title);
+		const path = `?path=share&service=${serviceName}&subject=${temp.subject}&link=${url}`;
 		if (!!temp.encodingValue?.[0]) {
 			const encoded_path = encode(path);
 			return `${CONFIG.FRONT_DOMAIN}/?encoded=${encoded_path}`;
@@ -262,12 +264,7 @@ const GetButton = () => {
 								const checked = selectedServices.includes(service.title);
 								return (
 									<Col xs={12} sm={8} key={i}>
-										<Service
-											{...service}
-											checked={checked}
-											onSelect={onAddService}
-											onRemove={onRemoveService}
-										/>
+										<Service {...service} checked={checked} onSelect={onAddService} onRemove={onRemoveService} />
 									</Col>
 								);
 							})}

--- a/src/Views/Pages/Share/index.tsx
+++ b/src/Views/Pages/Share/index.tsx
@@ -4,6 +4,8 @@ import { useLocation } from 'react-router-dom';
 import LoadingCover from '@src/Components/LoadingCover';
 import { getServiceURL } from '@src/Data/services.data';
 import { decode } from '@src/Tools/Utils/URLEncoding';
+import { toStandardName } from '@src/Tools/Utils/Standardize';
+import { standardNaming } from '@data/constants.data';
 
 const Share = () => {
 	const location = useLocation();
@@ -18,7 +20,8 @@ const Share = () => {
 		const subject = urlParams.get('subject') || '';
 		const link = urlParams.get('link') || '';
 
-		const url = getServiceURL(encodeURIComponent(link), subject)[service];
+		const serviceName = standardNaming[toStandardName(service)];
+		const url = getServiceURL(encodeURIComponent(link), subject)[serviceName];
 		setTimeout(() => {
 			window.open(url, '_self');
 		}, 100);


### PR DESCRIPTION
#### Reference Issues/PRs
#75 #76 
#### What does this implement/fix? Explain your changes.
Add a standard service name list containing suitable names to be used in the final constructed link:
`x`
`email`
`gmail`
`reddit`
`trello`
`blogger`
`yahoo_mail`
`telegram`
`whatsapp`
`facebook`
`linkedin`
`custom_share`
`hacker_news`
#### Any other comments?
The service names are now backward compatible by using `toStandardName` function.
